### PR TITLE
Python3 - fix: improve numpy-compatibility of lenFortStrAr

### DIFF
--- a/python/pyPamtra/core.py
+++ b/python/pyPamtra/core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 import csv
 import pickle as pickle

--- a/python/pyPamtra/descriptorFile.py
+++ b/python/pyPamtra/descriptorFile.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 import csv
 

--- a/python/pyPamtra/importer.py
+++ b/python/pyPamtra/importer.py
@@ -6,9 +6,9 @@ Collection of importer modules for the different input types.
 They all return a pyPamtra object that holds the profile information in the .p object.
 
 In addition ncToDict is provide to easily read necdf files into a dictionary.
-""" 
+"""
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 import datetime
 import random

--- a/python/pyPamtra/libWrapper.py
+++ b/python/pyPamtra/libWrapper.py
@@ -237,14 +237,13 @@ def lenFortStrAr(arr):
   '''
   get string length of a fortran string array
 
-  I'm not sure whether this change is related to Python 2.7 -> 3 or 
-  numpy 1.12 -> 1.19
+  This change is probably related to numpy 1.12 -> 1.16
   '''
-
-  if is3:
-    return arr.dtype.itemsize
-  else:
+  try:
     return len(arr)
+  except TypeError:
+    return arr.dtype.itemsize
+
 
 
 

--- a/python/pyPamtra/libWrapper.py
+++ b/python/pyPamtra/libWrapper.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
+from __future__ import division, print_function
 
 import os
 #import logging

--- a/python/pyPamtra/meteoSI.py
+++ b/python/pyPamtra/meteoSI.py
@@ -7,7 +7,7 @@
 # vaphet, pseudoAdiabLapseRate, rh2a, moist_rho2rh added by Max Maahn 2011
 # ----------------------------------------------------------
 #
-from __future__ import division
+from __future__ import division, print_function
 #from math import *
 #import sys
 import numpy as np

--- a/python/pyPamtra/plot.py
+++ b/python/pyPamtra/plot.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 import datetime
 import matplotlib.pyplot as plt

--- a/python/pyPamtra/tools.py
+++ b/python/pyPamtra/tools.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 import traceback
 import warnings

--- a/src/descriptor_file.f90
+++ b/src/descriptor_file.f90
@@ -98,7 +98,7 @@ subroutine read_descriptor_file(errorstatus)
                 b_ms_arr(1,1,1,i), alpha_as_arr(1,1,1,i), beta_as_arr(1,1,1,i), moment_in_arr(i), nbin_arr(1,1,1,i),&
                 dist_name_arr(i), p_1_arr(1,1,1,i), p_2_arr(1,1,1,i), p_3_arr(1,1,1,i),  &
                 p_4_arr(1,1,1,i), d_1_arr(1,1,1,i), d_2_arr(1,1,1,i), scat_name_arr(i), vel_size_mod_arr(i)
-      if ((verbose >= 4) .and. (i == 1)) write(6,'(a15,7(a12),a15,6(a12),2(a15))'),'hydro_name','as_ratio',&
+      if ((verbose >= 4) .and. (i == 1)) write(6,'(a15,7(a12),a15,6(a12),2(a15))') 'hydro_name','as_ratio',&
                                       'liq_ice','rho_ms','a_ms',&
                                      'b_ms','alpha_as','beta_as','moment_in','nbin','dist_name','p_1',&
                                       'p_2','p_3','p_4','d_1','d_2','scat_name', 'vel_size_mod'


### PR DESCRIPTION
fix: improve numpy-compatibility of lenFortStrAr

solves #27 

This Patch also includes some import of print_function and a FOTRAN legacy patch